### PR TITLE
Migrate to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,74 @@
+name: build
+on:
+  push:
+    branches:
+      - master
+      - release
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ["10.23.0", "12.19.0", "14.15.0", "15.2.0"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+        id: extract-branch
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test unit
+        run: npm run test:unit
+      - name: Test mutation
+        run: npm run test:mutation
+        env:
+          BRANCH_NAME: ${{ steps.extract-branch.outputs.branch }}
+          STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_TOKEN }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage-${{ matrix.node }}
+          path: coverage
+          retention-days: 1
+  quality:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download test results
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-15.2.0
+          path: coverage
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != ''
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/check-package-version.yml
+++ b/.github/workflows/check-package-version.yml
@@ -1,0 +1,44 @@
+name: check-package-version
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  check-package-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get NPM version is new
+        id: check
+        uses: EndBug/version-check@v1.6.0
+        with:
+          diff-search: true
+          file-name: ./package.json
+          file-url: https://unpkg.com/@data-provider/browser-storage@latest/package.json
+          static-checking: localIsNew
+      - name: Check version is new
+        if: steps.check.outputs.changed != 'true'
+        run: |
+          echo "Version not changed"
+          exit 1
+      - name: Get NPM version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.1.0
+      - name: Check Changelog version
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2.0.0
+        with:
+          version: ${{ steps.package-version.outputs.current-version }}
+          path: ./CHANGELOG.md
+      - name: Read version from Sonar config
+        id: sonar-version
+        uses: christian-draeger/read-properties@1.0.1
+        with:
+          path: './sonar-project.properties'
+          property: 'sonar.projectVersion'
+      - name: Check Sonar version
+        if: steps.sonar-version.outputs.value != steps.package-version.outputs.current-version
+        run: |
+          echo "Version not changed"
+          exit 1

--- a/.github/workflows/publish-to-github.yml
+++ b/.github/workflows/publish-to-github.yml
@@ -1,0 +1,21 @@
+name: publish-to-github
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm ci
+    - run: npm run build
+    # Setup .npmrc file to publish to GitHub Packages
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://npm.pkg.github.com'
+        # Defaults to the user or organization that owns the workflow file
+        scope: '@data-provider'
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,18 @@
+name: publish-to-npm
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org/'
+    - run: npm ci
+    - run: npm run build
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-version: ~> 1.0
-import: data-provider/ci-cd-shared-config:.travis.yml@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 ### Changed
+- chore(ci): Migrate from Travis CI to GitHub actions. (#100)
+- chore(deps): Support all Node.js releases that have not passed their end date
 ### Fixed
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status][travisci-image]][travisci-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url] [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fdata-provider%2Fbrowser-storage%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/data-provider/browser-storage/master)
+[![Build status][build-image]][build-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Quality Gate][quality-gate-image]][quality-gate-url] [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fdata-provider%2Fbrowser-storage%2Fmaster)](https://dashboard.stryker-mutator.io/reports/github.com/data-provider/browser-storage/master)
 
 [![NPM dependencies][npm-dependencies-image]][npm-dependencies-url] [![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com) [![Last commit][last-commit-image]][last-commit-url] [![Last release][release-image]][release-url] 
 
@@ -133,8 +133,8 @@ Please read the [contributing guidelines](.github/CONTRIBUTING.md) and [code of 
 
 [coveralls-image]: https://coveralls.io/repos/github/data-provider/browser-storage/badge.svg
 [coveralls-url]: https://coveralls.io/github/data-provider/browser-storage
-[travisci-image]: https://travis-ci.com/data-provider/browser-storage.svg?branch=master
-[travisci-url]: https://travis-ci.com/data-provider/browser-storage
+[build-image]: https://github.com/data-provider/browser-storage/workflows/build/badge.svg?branch=master
+[build-url]: https://github.com/data-provider/browser-storage/actions?query=workflow%3Abuild+branch%3Amaster
 [last-commit-image]: https://img.shields.io/github/last-commit/data-provider/browser-storage.svg
 [last-commit-url]: https://github.com/data-provider/browser-storage/commits
 [license-image]: https://img.shields.io/npm/l/@data-provider/browser-storage.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -4140,19 +4140,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "coveralls": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
-      "integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
-      "dev": true,
-      "requires": {
-        "js-yaml": "^3.13.1",
-        "lcov-parse": "^1.0.0",
-        "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7337,12 +7324,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "lcov-parse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7560,12 +7541,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {
@@ -8559,34 +8534,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
     },
     "request-promise-core": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
     "lint-staged": "lint-staged",
     "build": "rollup --config",
     "test": "jest",
-    "test:ci": "npm run test -- --coverage --ci --verbose=false --coverageReporters=lcov --coverageReporters=text-summary && npm run test:mutation",
-    "test:coverage": "npm run test:ci",
-    "test:mutation": "stryker run",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "test:unit": "npm run test -- --coverage --ci --verbose=false --coverageReporters=lcov --coverageReporters=text-summary",
+    "test:mutation": "stryker run"
   },
   "peerDependencies": {
     "@data-provider/core": "2.x"
@@ -55,7 +53,6 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "26.6.3",
     "babel-polyfill": "6.26.0",
-    "coveralls": "3.0.9",
     "eslint": "7.14.0",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
@@ -79,6 +76,6 @@
     }
   },
   "engines": {
-    "node": "12.x || 14.x || 15.x"
+    "node": "10.x || 12.x || 14.x || 15.x"
   }
 }


### PR DESCRIPTION
### Changed
- chore(ci): Migrate from Travis CI to GitHub actions. (#100)
- chore(deps): Support all Node.js releases that have not passed their end date

