### PR TITLE
Release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+### Changed
+### Fixed
+### Removed
+
+## [2.2.2] - 2020-12-27
+
+### Added
 - docs(readme): Add example about using default tag
+
 ### Changed
 - chore(deps): Update dependencies
 - refactor: Use baseTags getter to define base tag (#109)
-### Fixed
-### Removed
 
 ## [2.2.1] - 2020-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 ### Changed
+- chore(deps): Update dependencies
 ### Fixed
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - docs(readme): Add example about using default tag
 ### Changed
 - chore(deps): Update dependencies
+- refactor: Use baseTags getter to define base tag (#109)
 ### Fixed
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- docs(readme): Add example about using default tag
 ### Changed
 - chore(deps): Update dependencies
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ userPreferences.query({ prop: "cookiesAccepted" }).delete()
 userPreferences.delete();
 ```
 
+## Tags
+
+Providers created with this addon will have automatically the `browser-storage` tag, so you can select all of them together using the `providers` methods as in:
+
+```javascript
+import { providers } from "@data-provider/core";
+
+providers.getByTag("browser-storage").cleanCache();
+```
+
+Apart of this common tag, each different type of `browser-storage` origin also has next tags:
+
+* `LocalStorage`: "local-storage"
+* `SessionStorage`: "session-storage"
+
 ## Contributing
 
 Contributors are welcome.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/browser-storage",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2296,9 +2296,9 @@
       }
     },
     "@data-provider/core": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-2.8.2.tgz",
-      "integrity": "sha512-CQEXDY6dlwpTLH1FZearr0YKNPGGWMx3U+nnbS9NZckXGlalYH8RgRsxWTa0wSGwcA6Zj7Ddc80BMDk3MFCokw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@data-provider/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-X8y7LZioa7XNq4CzqPu7+nzfFMGQoeBNNJ6SGeHu0a4dE2SaXXBKuefB1T9mJcKgLbE3V3k1Nkm6tpVGzUDSNw==",
       "dev": true,
       "requires": {
         "is-promise": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@babel/core": "7.12.3",
     "@babel/preset-env": "7.12.1",
-    "@data-provider/core": "2.8.2",
+    "@data-provider/core": "2.9.0",
     "@rollup/plugin-babel": "5.2.2",
     "@rollup/plugin-commonjs": "17.0.0",
     "@rollup/plugin-json": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-provider/browser-storage",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Data Provider addon providing localStorage and sessionStorage origins",
   "keywords": [
     "data-provider",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=data-provider
 sonar.projectKey=data-provider-browser-storage
-sonar.projectVersion=2.2.1
+sonar.projectVersion=2.2.2
 
 sonar.sources=src,test
 sonar.exclusions=node_modules/**

--- a/src/LocalStorage.js
+++ b/src/LocalStorage.js
@@ -10,9 +10,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 import { Storage } from "./Storage";
+import { TAG, LOCAL_TAG } from "./tags";
 
 export class LocalStorage extends Storage {
   constructor(id, options, query) {
     super(id, { ...options, storageKey: "localStorage" }, query);
+  }
+
+  get baseTags() {
+    return [TAG, LOCAL_TAG];
   }
 }

--- a/src/SessionStorage.js
+++ b/src/SessionStorage.js
@@ -10,9 +10,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 */
 
 import { Storage } from "./Storage";
+import { TAG, SESSION_TAG } from "./tags";
 
 export class SessionStorage extends Storage {
   constructor(id, options, query) {
     super(id, { ...options, storageKey: "sessionStorage" }, query);
+  }
+
+  get baseTags() {
+    return [TAG, SESSION_TAG];
   }
 }

--- a/src/Storage.js
+++ b/src/Storage.js
@@ -13,12 +13,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 import { Provider } from "@data-provider/core";
 
-const TAG = "browser-storage";
-const storageKeysTags = {
-  localStorage: "local-storage",
-  sessionStorage: "session-storage",
-};
-
 class StorageMock {
   constructor() {
     this._value = "{}";
@@ -49,10 +43,7 @@ class StorageErrorMock {
 
 export class Storage extends Provider {
   constructor(id, options, query) {
-    const tags = options.tags ? [...options.tags] : [];
-    tags.unshift(storageKeysTags[options.storageKey]);
-    tags.unshift(TAG);
-    const extendedOptions = { ...options, tags };
+    const extendedOptions = { ...options };
     if (!query) {
       extendedOptions.parentId = id;
     }

--- a/src/tags.js
+++ b/src/tags.js
@@ -1,0 +1,3 @@
+export const TAG = "browser-storage";
+export const LOCAL_TAG = "local-storage";
+export const SESSION_TAG = "session-storage";


### PR DESCRIPTION
### Added
- docs(readme): Add example about using default tag

### Changed
- chore(deps): Update dependencies
- refactor: Use baseTags getter to define base tag (closes #109)